### PR TITLE
Add custom labels

### DIFF
--- a/app/options.html
+++ b/app/options.html
@@ -54,7 +54,7 @@
 
                         <accordion-group ng-repeat="key in keys track by $index" is-open="key.open">
                             <accordion-heading>
-                                <kbd ng-show="key.key" class="light">{{key.key}}</kbd><span class="shortcut-label">{{actionToLabel(key.action)}}</span>
+                                <kbd ng-show="key.key" class="light">{{key.key}}</kbd><span class="shortcut-label">{{keyLabel(key)}}</span>
                                 <a ng-click="deleteKey($index)" class="pull-right delete-link"><i class="fa fa-trash"></i> Delete </a>
                             </accordion-heading>
 

--- a/app/options.html
+++ b/app/options.html
@@ -63,11 +63,15 @@
                                     <label>Keyboard Shortcut</label>
                                     <input ng-model="key.key" class="kbd-input form-control" placeholder="Example: ctrl+b" type="text"/>
                                 </div>
-                                <div class="col-md-9">
+                                <div class="col-md-5">
                                     <label>Behavior</label>
                                     <select width="'100%'" chosen class="form-control" ng-model="key.action" ng-options="option.value as option.label group by option.group for option in actionOptions">
                                         <option value="none">Select behavior...</option>
                                     </select>
+                                </div>
+                                <div class="col-md-4">
+                                    <label>Label as</label>
+                                    <input ng-model="key.customName" class="custom-name form-control" placeholder="{{keyLabel(key)}}" type="text"/>
                                 </div>
                             </div>
 

--- a/app/options.html
+++ b/app/options.html
@@ -71,7 +71,7 @@
                                 </div>
                                 <div class="col-md-4">
                                     <label>Label as</label>
-                                    <input ng-model="key.customName" class="custom-name form-control" placeholder="{{keyLabel(key)}}" type="text"/>
+                                    <input ng-model="key.customName" class="form-control" placeholder="{{keyLabel(key)}}" type="text"/>
                                 </div>
                             </div>
 

--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -154,7 +154,7 @@ var doAction = function(keySetting) {
       if (keySetting.button) {
         document.querySelector(keySetting.button).click();
       }
-      message['action'] = 'nexttab';
+      message.action = 'nexttab';
       chrome.runtime.sendMessage(message);
       break;
     case 'disable':

--- a/app/scripts/options.js
+++ b/app/scripts/options.js
@@ -91,7 +91,7 @@ app.controller('ShortkeysOptionsCtrl', ['$scope', function($scope) {
    *
    * @param action
    */
-  $scope.actionToLabel = function(action) {
+  var actionToLabel = function(action) {
     if (action === 'none') {
       return 'New keyboard shortcut';
     }
@@ -99,6 +99,14 @@ app.controller('ShortkeysOptionsCtrl', ['$scope', function($scope) {
       if ($scope.actionOptions[i].value === action) {
         return $scope.actionOptions[i].label;
       }
+    }
+  };
+
+  $scope.keyLabel = function(key) {
+    if (key.customName) {
+      return key.customName;
+    } else {
+      return actionToLabel(key.action);
     }
   };
 


### PR DESCRIPTION
Shortly after I started using this extension, I found that I had many "Run JavaScript" shortkeys that I couldn't tell apart unless I expanded them and looked at the code. This branch allows the user to add a custom label to solve this issue.

Although I'm trying to solve the issue of multiple identical-looking JavaScript shortkeys, I think there are other use cases, such as using the label to note the bookmark triggered by the shortkey, or to note the site on which the shortkey will be active.

@mikecrittenden :wave: I kept it simple since this is my first time touching Angular, so let me know if you think this is :hankey: 

![untitled-3](https://cloud.githubusercontent.com/assets/4692673/13908081/25ac8d5c-eeb9-11e5-97ca-800ef9f4c3b3.gif)

