### PR TITLE
Always append script but trigger action only when site matches

### DIFF
--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -174,13 +174,12 @@ var doAction = function(keySetting) {
  * @param keySetting
  */
 var activateKey = function(keySetting) {
-  if (isAllowedSite(keySetting)) {
-    var action = function() {
-      doAction(keySetting);
-      return false;
-    };
-    Mousetrap.bind(keySetting.key, action);
-  }
+  var action = function() {
+    if (!isAllowedSite(keySetting)) return false;
+    doAction(keySetting);
+    return false;
+  };
+  Mousetrap.bind(keySetting.key, action);
 };
 
 /**


### PR DESCRIPTION
This fixes the bug where actions aren't triggered for pages that use javascript to navigate (aka single page apps).