### PR TITLE
Updated deprecated methods...

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -13,11 +13,11 @@ function copyToClipboard(text) {
 }
 
 function selectTab(direction) {
-  chrome.tabs.query( {currentWindow: true}, (tabs) => {
+  chrome.tabs.query({currentWindow: true}, (tabs) => {
     if (tabs.length <= 1) {
       return;
     }
-    chrome.tabs.query( {currentWindow: true, active: true}, (currentTabInArray) => {
+    chrome.tabs.query({currentWindow: true, active: true}, (currentTabInArray) => {
       var currentTab = currentTabInArray[0];
       var toSelect;
       switch (direction) {
@@ -64,7 +64,7 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
     chrome.tabs.create({});
   }
   else if (action === 'closetab') {
-    chrome.tabs.query( {currentWindow: true, active: true}, (tab) => {
+    chrome.tabs.query({currentWindow: true, active: true}, (tab) => {
       chrome.tabs.remove(tab[0].id);
     });
   }
@@ -74,7 +74,7 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
     });
   }
   else if (action === 'onlytab') {
-    chrome.tabs.query( {currentWindow: true, pinned: false, active: false}, (tabs) => {
+    chrome.tabs.query({currentWindow: true, pinned: false, active: false}, (tabs) => {
       var ids = [];
       tabs.forEach(function(tab) {
         ids.push(tab.id);
@@ -83,7 +83,7 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
     });
   }
   else if (action === 'togglepin') {
-    chrome.tabs.query( {active: true, currentWindow: true}, (tab) => {
+    chrome.tabs.query({active: true, currentWindow: true}, (tab) => {
       var toggle = !tab[0].pinned;
       chrome.tabs.update(tab[0].id, { pinned: toggle });
     });

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -13,7 +13,7 @@ function copyToClipboard(text) {
 }
 
 function selectTab(direction) {
-  chrome.tabs.query({windowId: chrome.windows.WINDOW_ID_CURRENT}, (tabs) => {
+  chrome.tabs.query({currentWindow: true}, (tabs) => {
     if (tabs.length <= 1) {
       return;
     }
@@ -34,7 +34,8 @@ function selectTab(direction) {
           toSelect = tabs[tabs.length - 1];
           break;
       }
-      chrome.tabs.update(toSelect.id, { highlighted: true });
+      chrome.tabs.update(toSelect.id, {highlighted: true});
+      chrome.tabs.update(currentTab.id, {highlighted: false});
     });
   });
 }

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -64,12 +64,12 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
     chrome.tabs.create({});
   }
   else if (action === 'closetab') {
-    chrome.tabs.query({active: true}, (tab) => {
+    chrome.tabs.query({active: true, currentWindow: true}, (tab) => {
       chrome.tabs.remove(tab[0].id);
     });
   }
   else if (action === 'clonetab') {
-    chrome.tabs.query({active: true}, (tab) => {
+    chrome.tabs.query({active: true, currentWindow: true}, (tab) => {
       chrome.tabs.duplicate(tab[0].id);
     });
   }
@@ -83,7 +83,7 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
     });
   }
   else if (action === 'togglepin') {
-    chrome.tabs.query({active: true}, (tab) => {
+    chrome.tabs.query({active: true, currentWindow: true}, (tab) => {
       var toggle = !tab[0].pinned;
       chrome.tabs.update(tab[0].id, { pinned: toggle });
     });

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -110,7 +110,7 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
       }
       chrome.tabs.query(queryOption, function (tabs) {
         if (tabs.length > 0) {
-          chrome.tabs.update(tabs[0].id, {highlighted: true});
+          chrome.tabs.update(tabs[0].id, {selected: true});
           chrome.windows.update(tabs[0].windowId, {focused: true});
         } else {
           createNewTab();

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -13,11 +13,12 @@ function copyToClipboard(text) {
 }
 
 function selectTab(direction) {
-  chrome.tabs.getAllInWindow(null, function(tabs) {
+  chrome.tabs.query({windowId: chrome.windows.WINDOW_ID_CURRENT}, (tabs) => {
     if (tabs.length <= 1) {
       return;
     }
-    chrome.tabs.getSelected(null, function(currentTab) {
+    chrome.tabs.query({active: true, currentWindow: true}, (currentTabInArray) => {
+      var currentTab = currentTabInArray[0];
       var toSelect;
       switch (direction) {
         case 'next':
@@ -33,7 +34,7 @@ function selectTab(direction) {
           toSelect = tabs[tabs.length - 1];
           break;
       }
-      chrome.tabs.update(toSelect.id, { selected: true });
+      chrome.tabs.update(toSelect.id, { highlighted: true });
     });
   });
 }
@@ -62,12 +63,12 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
     chrome.tabs.create({});
   }
   else if (action === 'closetab') {
-    chrome.tabs.getSelected(null, function(tab){
+    chrome.tabs.query({active: true}, (tab) => {
       chrome.tabs.remove(tab.id);
     });
   }
   else if (action === 'clonetab') {
-    chrome.tabs.getSelected(null, function(tab){
+    chrome.tabs.query({active: true}, (tab) => {
       chrome.tabs.duplicate(tab.id);
     });
   }
@@ -81,7 +82,7 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
     });
   }
   else if (action === 'togglepin') {
-    chrome.tabs.getSelected(null, function(tab){
+    chrome.tabs.query({active: true}, (tab) => {
       var toggle = !tab.pinned;
       chrome.tabs.update(tab.id, { pinned: toggle });
     });
@@ -108,7 +109,7 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
       }
       chrome.tabs.query(queryOption, function (tabs) {
         if (tabs.length > 0) {
-          chrome.tabs.update(tabs[0].id, {selected: true});
+          chrome.tabs.update(tabs[0].id, {highlighted: true});
           chrome.windows.update(tabs[0].windowId, {focused: true});
         } else {
           createNewTab();

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -65,12 +65,12 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
   }
   else if (action === 'closetab') {
     chrome.tabs.query({active: true}, (tab) => {
-      chrome.tabs.remove(tab.id);
+      chrome.tabs.remove(tab[0].id);
     });
   }
   else if (action === 'clonetab') {
     chrome.tabs.query({active: true}, (tab) => {
-      chrome.tabs.duplicate(tab.id);
+      chrome.tabs.duplicate(tab[0].id);
     });
   }
   else if (action === 'onlytab') {
@@ -84,8 +84,8 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
   }
   else if (action === 'togglepin') {
     chrome.tabs.query({active: true}, (tab) => {
-      var toggle = !tab.pinned;
-      chrome.tabs.update(tab.id, { pinned: toggle });
+      var toggle = !tab[0].pinned;
+      chrome.tabs.update(tab[0].id, { pinned: toggle });
     });
   }
   else if (action === 'copyurl') {

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -13,11 +13,11 @@ function copyToClipboard(text) {
 }
 
 function selectTab(direction) {
-  chrome.tabs.query({currentWindow: true}, (tabs) => {
+  chrome.tabs.query( {currentWindow: true}, (tabs) => {
     if (tabs.length <= 1) {
       return;
     }
-    chrome.tabs.query({active: true, currentWindow: true}, (currentTabInArray) => {
+    chrome.tabs.query( {currentWindow: true, active: true}, (currentTabInArray) => {
       var currentTab = currentTabInArray[0];
       var toSelect;
       switch (direction) {
@@ -64,17 +64,17 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
     chrome.tabs.create({});
   }
   else if (action === 'closetab') {
-    chrome.tabs.query({active: true, currentWindow: true}, (tab) => {
+    chrome.tabs.query( {currentWindow: true, active: true}, (tab) => {
       chrome.tabs.remove(tab[0].id);
     });
   }
   else if (action === 'clonetab') {
-    chrome.tabs.query({active: true, currentWindow: true}, (tab) => {
+    chrome.tabs.query( {currentWindow: true, active: true}, (tab) => {
       chrome.tabs.duplicate(tab[0].id);
     });
   }
   else if (action === 'onlytab') {
-    chrome.tabs.query({ windowId: chrome.windows.WINDOW_ID_CURRENT, pinned: false, active: false }, function(tabs){
+    chrome.tabs.query( {currentWindow: true, pinned: false, active: false}, (tabs) => {
       var ids = [];
       tabs.forEach(function(tab) {
         ids.push(tab.id);
@@ -83,7 +83,7 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
     });
   }
   else if (action === 'togglepin') {
-    chrome.tabs.query({active: true, currentWindow: true}, (tab) => {
+    chrome.tabs.query( {active: true, currentWindow: true}, (tab) => {
       var toggle = !tab[0].pinned;
       chrome.tabs.update(tab[0].id, { pinned: toggle });
     });


### PR DESCRIPTION
*chrome.tabs.getSelected* and *chrome.tabs.getAllInWindow* methods are deprecated. 
It's proposed to use *chrome.tabs.query* instead.
.
*selected* tab property is also deprecated. It's proposed to use *highlighted* instead.
  
see --> https://developer.chrome.com/extensions/tabs

It should work :)